### PR TITLE
require DOMParser so it doesn't throw an error

### DIFF
--- a/src/parseHTML.js
+++ b/src/parseHTML.js
@@ -1,5 +1,5 @@
 /* @flow */
-
+var DOMParser = require('dom-parser');
 export default function parseHTML(html: string): Element {
   let doc;
   if (typeof DOMParser !== 'undefined') {


### PR DESCRIPTION
Require DOMParser so it doesn't throw a server error for SSR or if used only the server!