### PR TITLE
add typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "immutable": "3.x.x"
   },
   "devDependencies": {
+    "@types/draft-js": "^0.7.33",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-eslint": "^7.0.0",
@@ -41,10 +42,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/sstur/draft-js-import-html.git"
   },
-  "keywords": [
-    "draft-js",
-    "import-html"
-  ],
+  "keywords": ["draft-js", "import-html"],
   "author": "sstur@me.com",
   "contributors": [
     {

--- a/typings/draft-js-import-html-tests.ts
+++ b/typings/draft-js-import-html-tests.ts
@@ -1,0 +1,14 @@
+import { ContentState } from 'draft-js';
+import { stateFromHTML } from 'draft-js-import-html';
+
+const html = '<div>testing</div>';
+
+const resultWithOutOptions: ContentState = stateFromHTML(html);
+
+const parser = (html: string) => {
+  let doc = document.implementation.createHTMLDocument('');
+  doc.documentElement.innerHTML = html;
+  return doc.body;
+};
+
+const resultWithOptionalParser: ContentState = stateFromHTML(html, { parser });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'draft-js-import-html' {
+  import draftjs = require('draft-js');
+
+  export interface Options {
+    parser(html: string): HTMLElement;
+  }
+
+  export function stateFromHTML(content: string, options?: Options): draftjs.ContentState;
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": true,
+    "strictNullChecks": false,
+    "baseUrl": "./",
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": ["index.d.ts", "draft-js-import-html-tests.ts"]
+}


### PR DESCRIPTION
Hey! I've been working with your `draft-js` import and export packages, and I noticed this one didn't have its own declaration file, so I figured I'd add one. 

I followed the patterns established in `draft-js-export-html` but lmk if you have any feedback!